### PR TITLE
fix: add stateless_http=True to FastMCP constructor

### DIFF
--- a/src/zhcorpus/mcp/server.py
+++ b/src/zhcorpus/mcp/server.py
@@ -67,7 +67,7 @@ Wiktextract (multi), JMdict (ja), MiniMax translations (ar, es, fa, hi, ko, pt, 
 - All data stays local. The server binds to localhost only.
 """
 
-mcp = FastMCP("zhcorpus", instructions=_INSTRUCTIONS)
+mcp = FastMCP("zhcorpus", instructions=_INSTRUCTIONS, stateless_http=True)
 
 # ---------------------------------------------------------------------------
 # Global state — configured lazily


### PR DESCRIPTION
## Summary
- Adds `stateless_http=True` to the `FastMCP()` constructor in `src/zhcorpus/mcp/server.py`
- Prevents `-32600 Session not found` errors when the MCP server restarts
- Each HTTP request is now independent — no session tracking needed

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)